### PR TITLE
Add unit tests for PostsController

### DIFF
--- a/BBS.sln
+++ b/BBS.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.0.31410.414
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bbs.Api", "Bbs.Api\\Bbs.Api.csproj", "{2DBB80C2-09BF-4CBE-8481-ED52ACC08C24}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bbs.Api.Tests", "Bbs.Api.Tests\\Bbs.Api.Tests.csproj", "{700852AE-772F-497C-8E64-D0284FABA253}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -14,6 +16,10 @@ Global
         {2DBB80C2-09BF-4CBE-8481-ED52ACC08C24}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {2DBB80C2-09BF-4CBE-8481-ED52ACC08C24}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {2DBB80C2-09BF-4CBE-8481-ED52ACC08C24}.Release|Any CPU.Build.0 = Release|Any CPU
+        {700852AE-772F-497C-8E64-D0284FABA253}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {700852AE-772F-497C-8E64-D0284FABA253}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {700852AE-772F-497C-8E64-D0284FABA253}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {700852AE-772F-497C-8E64-D0284FABA253}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/Bbs.Api.Tests/Bbs.Api.Tests.csproj
+++ b/Bbs.Api.Tests/Bbs.Api.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Bbs.Api\Bbs.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/Bbs.Api.Tests/PostsControllerTests.cs
+++ b/Bbs.Api.Tests/PostsControllerTests.cs
@@ -1,0 +1,45 @@
+using Bbs.Api.Controllers;
+using Bbs.Api.Data;
+using Bbs.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Bbs.Api.Tests;
+
+public class PostsControllerTests
+{
+    private static BbsContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BbsContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new BbsContext(options);
+    }
+
+    [Fact]
+    public async Task GetPost_ReturnsNotFound_WhenPostMissing()
+    {
+        using var context = CreateContext();
+        var controller = new PostsController(context);
+
+        var result = await controller.GetPost(1);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task CreatePost_PersistsPost()
+    {
+        using var context = CreateContext();
+        var controller = new PostsController(context);
+        var newPost = new Post { Title = "Hello", Content = "World" };
+
+        var actionResult = await controller.CreatePost(newPost);
+        var created = Assert.IsType<CreatedAtActionResult>(actionResult.Result);
+        var createdPost = Assert.IsType<Post>(created.Value);
+
+        Assert.Equal("Hello", createdPost.Title);
+        Assert.Single(context.Posts);
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test project for Bbs.Api
- cover PostsController GetPost and CreatePost using in-memory EF Core

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68abca16c9c4832f887a169b4aa7792e