### PR TITLE
Use API in web frontend

### DIFF
--- a/BBS.Web/BBS.Web.csproj
+++ b/BBS.Web/BBS.Web.csproj
@@ -5,10 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\\BBS.Core\\BBS.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/BBS.Web/Controllers/PostsController.cs
+++ b/BBS.Web/Controllers/PostsController.cs
@@ -1,21 +1,22 @@
-using BBS.Core.Data;
+using System.Net.Http;
+using System.Net.Http.Json;
+using BBS.Core.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace BBS.Web.Controllers;
 
 public class PostsController : Controller
 {
-    private readonly BbsContext _context;
+    private readonly HttpClient _client;
 
-    public PostsController(BbsContext context)
+    public PostsController(IHttpClientFactory httpClientFactory)
     {
-        _context = context;
+        _client = httpClientFactory.CreateClient("BbsApi");
     }
 
     public async Task<IActionResult> Index()
     {
-        var posts = await _context.Posts.Include(p => p.Comments).ToListAsync();
-        return View(posts);
+        var posts = await _client.GetFromJsonAsync<List<Post>>("api/posts");
+        return View(posts ?? new List<Post>());
     }
 }

--- a/BBS.Web/Program.cs
+++ b/BBS.Web/Program.cs
@@ -1,12 +1,10 @@
-using BBS.Core.Data;
-using Microsoft.EntityFrameworkCore;
+using System;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllersWithViews();
-
-builder.Services.AddDbContext<BbsContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddHttpClient("BbsApi", client =>
+    client.BaseAddress = new Uri(builder.Configuration["ApiBaseUrl"]!));
 
 var app = builder.Build();
 

--- a/BBS.Web/appsettings.json
+++ b/BBS.Web/appsettings.json
@@ -1,7 +1,5 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=BbsDb;Trusted_Connection=True;MultipleActiveResultSets=true"
-  },
+  "ApiBaseUrl": "https://localhost:5001/",
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- Remove EF dependencies from BBS.Web and configure HttpClient
- Fetch posts in web controller via BBS.Api
- Provide API base URL via configuration

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68abd5bbed58832f91f339f2a5f7bd09