### PR TITLE
Implement generic repository pattern in infrastructure

### DIFF
--- a/BBS.Infrastructure/Repositories/Repository.cs
+++ b/BBS.Infrastructure/Repositories/Repository.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using BBS.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BBS.Infrastructure.Repositories;
+
+public class Repository<T> where T : class
+{
+    protected readonly BbsContext _context;
+    protected readonly DbSet<T> _dbSet;
+
+    public Repository(BbsContext context)
+    {
+        _context = context;
+        _dbSet = _context.Set<T>();
+    }
+
+    public virtual async Task<List<T>> GetAllAsync()
+    {
+        return await _dbSet.ToListAsync();
+    }
+
+    public virtual async Task<T?> GetByIdAsync(int id)
+    {
+        return await _dbSet.FindAsync(id).AsTask();
+    }
+
+    public virtual async Task<T> AddAsync(T entity)
+    {
+        _dbSet.Add(entity);
+        await _context.SaveChangesAsync();
+        return entity;
+    }
+
+    public virtual async Task UpdateAsync(T entity)
+    {
+        _dbSet.Update(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public virtual async Task DeleteAsync(int id)
+    {
+        var entity = await GetByIdAsync(id);
+        if (entity != null)
+        {
+            _dbSet.Remove(entity);
+            await _context.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce generic `Repository<T>` base class for CRUD operations
- refactor `PostRepository` to inherit from the generic repository and override post queries

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68abde968d4c832f904cf027e6880897