### PR TITLE
Add basic authentication and require login for posting

### DIFF
--- a/BBS.Api.Tests/AuthControllerTests.cs
+++ b/BBS.Api.Tests/AuthControllerTests.cs
@@ -1,0 +1,60 @@
+using BBS.Api.Controllers;
+using BBS.Application.Services;
+using BBS.Domain.Repositories;
+using BBS.Infrastructure.Data;
+using BBS.Infrastructure.Repositories;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace BBS.Api.Tests;
+
+public class AuthControllerTests
+{
+    private static (BbsContext context, AuthController controller) CreateController()
+    {
+        var options = new DbContextOptionsBuilder<BbsContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new BbsContext(options);
+        IUserRepository repository = new UserRepository(context);
+        IUserService service = new UserService(repository);
+        var settings = new Dictionary<string, string>
+        {
+            { "Jwt:Key", "k" },
+            { "Jwt:Issuer", "i" },
+            { "Jwt:Audience", "a" }
+        };
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings!)
+            .Build();
+        var controller = new AuthController(service, configuration);
+        return (context, controller);
+    }
+
+    [Fact]
+    public async Task Register_ReturnsConflict_WhenEmailExists()
+    {
+        var (context, controller) = CreateController();
+        using (context)
+        {
+            await controller.Register(new RegisterDto("test@example.com", "pass", "nick1"));
+            var result = await controller.Register(new RegisterDto("test@example.com", "pass", "nick2"));
+            Assert.IsType<ConflictResult>(result);
+        }
+    }
+
+    [Fact]
+    public async Task Register_ReturnsConflict_WhenNicknameExists()
+    {
+        var (context, controller) = CreateController();
+        using (context)
+        {
+            await controller.Register(new RegisterDto("test1@example.com", "pass", "nick"));
+            var result = await controller.Register(new RegisterDto("test2@example.com", "pass", "nick"));
+            Assert.IsType<ConflictResult>(result);
+        }
+    }
+}
+

--- a/BBS.Api.Tests/BBS.Api.Tests.csproj
+++ b/BBS.Api.Tests/BBS.Api.Tests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BBS.Api\BBS.Api.csproj" />

--- a/BBS.Api/BBS.Api.csproj
+++ b/BBS.Api/BBS.Api.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">

--- a/BBS.Api/Controllers/AuthController.cs
+++ b/BBS.Api/Controllers/AuthController.cs
@@ -1,0 +1,57 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using BBS.Application.Services;
+using BBS.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+
+namespace BBS.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly IUserService _service;
+    private readonly IConfiguration _configuration;
+
+    public AuthController(IUserService service, IConfiguration configuration)
+    {
+        _service = service;
+        _configuration = configuration;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegisterDto dto)
+    {
+        var success = await _service.RegisterAsync(dto.Email, dto.Password, dto.Nickname);
+        if (!success) return Conflict();
+        return Ok();
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginDto dto)
+    {
+        var user = await _service.AuthenticateAsync(dto.Email, dto.Password);
+        if (user == null) return Unauthorized();
+        var token = GenerateToken(user);
+        return Ok(new { token });
+    }
+
+    private string GenerateToken(User user)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            claims: new[] { new Claim(ClaimTypes.Name, user.Id) },
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+
+public record RegisterDto(string Email, string Password, string Nickname);
+public record LoginDto(string Email, string Password);
+

--- a/BBS.Api/Controllers/PostsController.cs
+++ b/BBS.Api/Controllers/PostsController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using BBS.Application.Services;
 using BBS.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BBS.Api.Controllers;
@@ -35,6 +36,7 @@ public class PostsController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize]
     public async Task<ActionResult<Post>> CreatePost(Post post)
     {
         var created = await _service.CreatePostAsync(post);
@@ -42,6 +44,7 @@ public class PostsController : ControllerBase
     }
 
     [HttpPost("{postId}/comments")]
+    [Authorize]
     public async Task<ActionResult<Comment>> AddComment(int postId, Comment comment)
     {
         try
@@ -69,3 +72,4 @@ public class PostsController : ControllerBase
         }
     }
 }
+

--- a/BBS.Api/appsettings.json
+++ b/BBS.Api/appsettings.json
@@ -2,6 +2,11 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=BbsDb;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
+  "Jwt": {
+    "Key": "supersecretkey",
+    "Issuer": "BBS",
+    "Audience": "BBS"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/BBS.Application/Services/IUserService.cs
+++ b/BBS.Application/Services/IUserService.cs
@@ -1,0 +1,10 @@
+using BBS.Domain.Entities;
+
+namespace BBS.Application.Services;
+
+public interface IUserService
+{
+    Task<bool> RegisterAsync(string email, string password, string nickname);
+    Task<User?> AuthenticateAsync(string email, string password);
+}
+

--- a/BBS.Application/Services/UserService.cs
+++ b/BBS.Application/Services/UserService.cs
@@ -1,0 +1,46 @@
+using System.Security.Cryptography;
+using System.Text;
+using BBS.Domain.Entities;
+using BBS.Domain.Repositories;
+
+namespace BBS.Application.Services;
+
+public class UserService : IUserService
+{
+    private readonly IUserRepository _repository;
+
+    public UserService(IUserRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<bool> RegisterAsync(string email, string password, string nickname)
+    {
+        if (await _repository.GetByEmailAsync(email) != null) return false;
+        if (await _repository.GetByNicknameAsync(nickname) != null) return false;
+
+        var user = new User
+        {
+            Id = email,
+            Nickname = nickname,
+            PasswordHash = Hash(password)
+        };
+        await _repository.AddAsync(user);
+        return true;
+    }
+
+    public async Task<User?> AuthenticateAsync(string email, string password)
+    {
+        var user = await _repository.GetByEmailAsync(email);
+        if (user == null) return null;
+        return user.PasswordHash == Hash(password) ? user : null;
+    }
+
+    private static string Hash(string input)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(input));
+        return Convert.ToBase64String(bytes);
+    }
+}
+

--- a/BBS.Domain/Entities/User.cs
+++ b/BBS.Domain/Entities/User.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BBS.Domain.Entities;
+
+public class User
+{
+    [Key]
+    public string Id { get; set; } = default!; // Email as ID
+
+    [Required]
+    public string Nickname { get; set; } = default!;
+
+    [Required]
+    public string PasswordHash { get; set; } = default!;
+}
+

--- a/BBS.Domain/Repositories/IUserRepository.cs
+++ b/BBS.Domain/Repositories/IUserRepository.cs
@@ -1,0 +1,11 @@
+using BBS.Domain.Entities;
+
+namespace BBS.Domain.Repositories;
+
+public interface IUserRepository
+{
+    Task<User?> GetByEmailAsync(string email);
+    Task<User?> GetByNicknameAsync(string nickname);
+    Task<User> AddAsync(User user);
+}
+

--- a/BBS.Infrastructure/Data/BbsContext.cs
+++ b/BBS.Infrastructure/Data/BbsContext.cs
@@ -9,4 +9,12 @@ public class BbsContext : DbContext
 
     public DbSet<Post> Posts => Set<Post>();
     public DbSet<Comment> Comments => Set<Comment>();
+    public DbSet<User> Users => Set<User>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<User>().HasKey(u => u.Id);
+    }
 }
+

--- a/BBS.Infrastructure/Repositories/UserRepository.cs
+++ b/BBS.Infrastructure/Repositories/UserRepository.cs
@@ -1,0 +1,29 @@
+using BBS.Domain.Entities;
+using BBS.Domain.Repositories;
+using BBS.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BBS.Infrastructure.Repositories;
+
+public class UserRepository : IUserRepository
+{
+    private readonly BbsContext _context;
+
+    public UserRepository(BbsContext context)
+    {
+        _context = context;
+    }
+
+    public Task<User?> GetByEmailAsync(string email) => _context.Users.FindAsync(email).AsTask();
+
+    public Task<User?> GetByNicknameAsync(string nickname) =>
+        _context.Users.FirstOrDefaultAsync(u => u.Nickname == nickname);
+
+    public async Task<User> AddAsync(User user)
+    {
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+        return user;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add user entity with email IDs and unique nicknames
- implement auth service and controller issuing JWT tokens
- restrict post and comment creation to authenticated users

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68abe1c039b4832fa2ac697c8068b145