### PR TITLE
Add authentication and post management to BBS Web

### DIFF
--- a/BBS.Api/Controllers/PostsController.cs
+++ b/BBS.Api/Controllers/PostsController.cs
@@ -39,8 +39,30 @@ public class PostsController : ControllerBase
     [Authorize]
     public async Task<ActionResult<Post>> CreatePost(Post post)
     {
-        var created = await _service.CreatePostAsync(post);
+        var userId = User.Identity!.Name!;
+        var created = await _service.CreatePostAsync(post, userId);
         return CreatedAtAction(nameof(GetPost), new { id = created.Id }, created);
+    }
+
+    [HttpPut("{id}")]
+    [Authorize]
+    public async Task<IActionResult> UpdatePost(int id, Post post)
+    {
+        var userId = User.Identity!.Name!;
+        post.Id = id;
+        var ok = await _service.UpdatePostAsync(post, userId);
+        if (!ok) return Forbid();
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    [Authorize]
+    public async Task<IActionResult> DeletePost(int id)
+    {
+        var userId = User.Identity!.Name!;
+        var ok = await _service.DeletePostAsync(id, userId);
+        if (!ok) return Forbid();
+        return NoContent();
     }
 
     [HttpPost("{postId}/comments")]

--- a/BBS.Application/Services/IPostService.cs
+++ b/BBS.Application/Services/IPostService.cs
@@ -8,7 +8,9 @@ public interface IPostService
 {
     Task<IEnumerable<Post>> GetPostsAsync();
     Task<Post?> GetPostAsync(int id);
-    Task<Post> CreatePostAsync(Post post);
+    Task<Post> CreatePostAsync(Post post, string authorId);
+    Task<bool> UpdatePostAsync(Post post, string userId);
+    Task<bool> DeletePostAsync(int id, string userId);
     Task<Comment> AddCommentAsync(int postId, Comment comment);
     Task<IEnumerable<Comment>> GetCommentsAsync(int postId);
 }

--- a/BBS.Application/Services/PostService.cs
+++ b/BBS.Application/Services/PostService.cs
@@ -17,7 +17,29 @@ public class PostService : IPostService
 
     public Task<Post?> GetPostAsync(int id) => _repository.GetPostAsync(id);
 
-    public Task<Post> CreatePostAsync(Post post) => _repository.AddPostAsync(post);
+    public Task<Post> CreatePostAsync(Post post, string authorId)
+    {
+        post.AuthorId = authorId;
+        return _repository.AddPostAsync(post);
+    }
+
+    public async Task<bool> UpdatePostAsync(Post post, string userId)
+    {
+        var existing = await _repository.GetPostAsync(post.Id);
+        if (existing == null || existing.AuthorId != userId) return false;
+        existing.Title = post.Title;
+        existing.Content = post.Content;
+        await _repository.UpdatePostAsync(existing);
+        return true;
+    }
+
+    public async Task<bool> DeletePostAsync(int id, string userId)
+    {
+        var existing = await _repository.GetPostAsync(id);
+        if (existing == null || existing.AuthorId != userId) return false;
+        await _repository.DeletePostAsync(id);
+        return true;
+    }
 
     public Task<Comment> AddCommentAsync(int postId, Comment comment) => _repository.AddCommentAsync(postId, comment);
 

--- a/BBS.Domain/Entities/Post.cs
+++ b/BBS.Domain/Entities/Post.cs
@@ -7,5 +7,6 @@ public class Post
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
+    public string AuthorId { get; set; } = string.Empty;
     public List<Comment> Comments { get; set; } = new();
 }

--- a/BBS.Domain/Repositories/IPostRepository.cs
+++ b/BBS.Domain/Repositories/IPostRepository.cs
@@ -9,6 +9,8 @@ public interface IPostRepository
     Task<List<Post>> GetPostsAsync();
     Task<Post?> GetPostAsync(int id);
     Task<Post> AddPostAsync(Post post);
+    Task UpdatePostAsync(Post post);
+    Task DeletePostAsync(int id);
     Task<Comment> AddCommentAsync(int postId, Comment comment);
     Task<List<Comment>> GetCommentsAsync(int postId);
 }

--- a/BBS.Infrastructure/Data/BbsContext.cs
+++ b/BBS.Infrastructure/Data/BbsContext.cs
@@ -15,6 +15,10 @@ public class BbsContext : DbContext
     {
         base.OnModelCreating(modelBuilder);
         modelBuilder.Entity<User>().HasKey(u => u.Id);
+        modelBuilder.Entity<Post>()
+            .HasOne<User>()
+            .WithMany()
+            .HasForeignKey(p => p.AuthorId);
     }
 }
 

--- a/BBS.Infrastructure/Repositories/PostRepository.cs
+++ b/BBS.Infrastructure/Repositories/PostRepository.cs
@@ -17,6 +17,10 @@ public class PostRepository : Repository<Post>, IPostRepository
 
     public async Task<Post> AddPostAsync(Post post) => await AddAsync(post);
 
+    public async Task UpdatePostAsync(Post post) => await UpdateAsync(post);
+
+    public async Task DeletePostAsync(int id) => await DeleteAsync(id);
+
     public async Task<Comment> AddCommentAsync(int postId, Comment comment)
     {
         var post = await _context.Posts.FindAsync(postId);

--- a/BBS.Web/Controllers/AccountController.cs
+++ b/BBS.Web/Controllers/AccountController.cs
@@ -1,0 +1,83 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBS.Web.Controllers;
+
+public class AccountController : Controller
+{
+    private readonly IHttpClientFactory _factory;
+
+    public AccountController(IHttpClientFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [HttpGet]
+    public IActionResult Register() => View();
+
+    [HttpPost]
+    public async Task<IActionResult> Register(RegisterDto dto)
+    {
+        var client = _factory.CreateClient("BbsApi");
+        var response = await client.PostAsJsonAsync("api/auth/register", dto);
+        if (response.IsSuccessStatusCode)
+            return RedirectToAction("Login");
+        ModelState.AddModelError(string.Empty, "Registration failed");
+        return View(dto);
+    }
+
+    [HttpGet]
+    public IActionResult Login() => View();
+
+    [HttpPost]
+    public async Task<IActionResult> Login(LoginDto dto)
+    {
+        var client = _factory.CreateClient("BbsApi");
+        var response = await client.PostAsJsonAsync("api/auth/login", dto);
+        if (!response.IsSuccessStatusCode)
+        {
+            ModelState.AddModelError(string.Empty, "Login failed");
+            return View(dto);
+        }
+        var result = await response.Content.ReadFromJsonAsync<LoginResult>();
+        if (result?.token == null)
+        {
+            ModelState.AddModelError(string.Empty, "Login failed");
+            return View(dto);
+        }
+        HttpContext.Session.SetString("token", result.token);
+        var email = GetEmailFromToken(result.token);
+        if (email != null)
+            HttpContext.Session.SetString("user", email);
+        return RedirectToAction("Index", "Posts");
+    }
+
+    public IActionResult Logout()
+    {
+        HttpContext.Session.Remove("token");
+        HttpContext.Session.Remove("user");
+        return RedirectToAction("Index", "Posts");
+    }
+
+    private static string? GetEmailFromToken(string token)
+    {
+        var parts = token.Split('.');
+        if (parts.Length < 2) return null;
+        var payload = parts[1];
+        switch (payload.Length % 4)
+        {
+            case 2: payload += "=="; break;
+            case 3: payload += "="; break;
+        }
+        var bytes = Convert.FromBase64String(payload.Replace('-', '+').Replace('_', '/'));
+        using var doc = JsonDocument.Parse(bytes);
+        if (doc.RootElement.TryGetProperty("unique_name", out var prop))
+            return prop.GetString();
+        return null;
+    }
+}
+
+public record RegisterDto(string Email, string Password, string Nickname);
+public record LoginDto(string Email, string Password);
+public record LoginResult(string token);

--- a/BBS.Web/Controllers/PostsController.cs
+++ b/BBS.Web/Controllers/PostsController.cs
@@ -1,5 +1,4 @@
-using System.Collections.Generic;
-using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using BBS.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
@@ -8,16 +7,87 @@ namespace BBS.Web.Controllers;
 
 public class PostsController : Controller
 {
-    private readonly HttpClient _client;
+    private readonly IHttpClientFactory _factory;
 
-    public PostsController(IHttpClientFactory httpClientFactory)
+    public PostsController(IHttpClientFactory factory)
     {
-        _client = httpClientFactory.CreateClient("BbsApi");
+        _factory = factory;
+    }
+
+    private HttpClient CreateClient()
+    {
+        var client = _factory.CreateClient("BbsApi");
+        var token = HttpContext.Session.GetString("token");
+        if (!string.IsNullOrEmpty(token))
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
     }
 
     public async Task<IActionResult> Index()
     {
-        var posts = await _client.GetFromJsonAsync<List<Post>>("api/posts");
+        var client = CreateClient();
+        var posts = await client.GetFromJsonAsync<List<Post>>("api/posts");
         return View(posts ?? new List<Post>());
+    }
+
+    public async Task<IActionResult> Details(int id)
+    {
+        var client = CreateClient();
+        var post = await client.GetFromJsonAsync<Post>($"api/posts/{id}");
+        if (post == null) return NotFound();
+        return View(post);
+    }
+
+    [HttpGet]
+    public IActionResult Create()
+    {
+        if (HttpContext.Session.GetString("token") == null)
+            return RedirectToAction("Login", "Account");
+        return View();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(Post post)
+    {
+        if (HttpContext.Session.GetString("token") == null)
+            return RedirectToAction("Login", "Account");
+        var client = CreateClient();
+        var response = await client.PostAsJsonAsync("api/posts", post);
+        if (response.IsSuccessStatusCode)
+            return RedirectToAction(nameof(Index));
+        return View(post);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Edit(int id)
+    {
+        if (HttpContext.Session.GetString("token") == null)
+            return RedirectToAction("Login", "Account");
+        var client = CreateClient();
+        var post = await client.GetFromJsonAsync<Post>($"api/posts/{id}");
+        if (post == null) return NotFound();
+        return View(post);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Edit(int id, Post post)
+    {
+        if (HttpContext.Session.GetString("token") == null)
+            return RedirectToAction("Login", "Account");
+        var client = CreateClient();
+        var response = await client.PutAsJsonAsync($"api/posts/{id}", post);
+        if (response.IsSuccessStatusCode)
+            return RedirectToAction(nameof(Index));
+        return View(post);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Delete(int id)
+    {
+        if (HttpContext.Session.GetString("token") == null)
+            return RedirectToAction("Login", "Account");
+        var client = CreateClient();
+        await client.DeleteAsync($"api/posts/{id}");
+        return RedirectToAction(nameof(Index));
     }
 }

--- a/BBS.Web/Program.cs
+++ b/BBS.Web/Program.cs
@@ -5,6 +5,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 builder.Services.AddHttpClient("BbsApi", client =>
     client.BaseAddress = new Uri(builder.Configuration["ApiBaseUrl"]!));
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession();
 
 var app = builder.Build();
 
@@ -19,6 +21,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseSession();
 app.UseAuthorization();
 
 app.MapControllerRoute(

--- a/BBS.Web/Views/Account/Login.cshtml
+++ b/BBS.Web/Views/Account/Login.cshtml
@@ -1,0 +1,16 @@
+@model LoginDto
+@{
+    ViewData["Title"] = "Login";
+}
+
+<form asp-action="Login" method="post" class="mt-3">
+    <div class="mb-3">
+        <label asp-for="Email" class="form-label"></label>
+        <input asp-for="Email" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Password" class="form-label"></label>
+        <input asp-for="Password" type="password" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>

--- a/BBS.Web/Views/Account/Register.cshtml
+++ b/BBS.Web/Views/Account/Register.cshtml
@@ -1,0 +1,20 @@
+@model RegisterDto
+@{
+    ViewData["Title"] = "Register";
+}
+
+<form asp-action="Register" method="post" class="mt-3">
+    <div class="mb-3">
+        <label asp-for="Email" class="form-label"></label>
+        <input asp-for="Email" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Nickname" class="form-label"></label>
+        <input asp-for="Nickname" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Password" class="form-label"></label>
+        <input asp-for="Password" type="password" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Register</button>
+</form>

--- a/BBS.Web/Views/Posts/Create.cshtml
+++ b/BBS.Web/Views/Posts/Create.cshtml
@@ -1,0 +1,17 @@
+@model Post
+@{
+    ViewData["Title"] = "Create Post";
+}
+
+<form asp-action="Create" method="post">
+    <div class="mb-3">
+        <label asp-for="Title" class="form-label"></label>
+        <input asp-for="Title" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Content" class="form-label"></label>
+        <textarea asp-for="Content" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a asp-action="Index" class="btn btn-secondary">Cancel</a>
+</form>

--- a/BBS.Web/Views/Posts/Details.cshtml
+++ b/BBS.Web/Views/Posts/Details.cshtml
@@ -1,0 +1,17 @@
+@model Post
+@{
+    ViewData["Title"] = "Post Details";
+    var user = Context.Session.GetString("user");
+}
+
+<div class="card">
+    <div class="card-body">
+        <h5 class="card-title">@Model.Title</h5>
+        <p class="card-text">@Model.Content</p>
+        <a asp-action="Index" class="btn btn-secondary">Back</a>
+        @if (user == Model.AuthorId)
+        {
+            <a class="btn btn-warning" href="/Posts/Edit/@Model.Id">Edit</a>
+        }
+    </div>
+</div>

--- a/BBS.Web/Views/Posts/Edit.cshtml
+++ b/BBS.Web/Views/Posts/Edit.cshtml
@@ -1,0 +1,18 @@
+@model Post
+@{
+    ViewData["Title"] = "Edit Post";
+}
+
+<form asp-action="Edit" method="post">
+    <input type="hidden" asp-for="Id" />
+    <div class="mb-3">
+        <label asp-for="Title" class="form-label"></label>
+        <input asp-for="Title" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Content" class="form-label"></label>
+        <textarea asp-for="Content" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a asp-action="Index" class="btn btn-secondary">Cancel</a>
+</form>

--- a/BBS.Web/Views/Posts/Index.cshtml
+++ b/BBS.Web/Views/Posts/Index.cshtml
@@ -1,10 +1,31 @@
-@model IEnumerable<BBS.Domain.Entities.Post>
+@model IEnumerable<Post>
+@{
+    ViewData["Title"] = "Posts";
+    var user = Context.Session.GetString("user");
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Posts</h1>
+    @if (user != null)
+    {
+        <a class="btn btn-primary" href="/Posts/Create">New Post</a>
+    }
+</div>
 
 @foreach (var post in Model)
 {
-    <article>
-        <h2>@post.Title</h2>
-        <p>@post.Content</p>
-        <p>@post.Comments.Count comment(s)</p>
-    </article>
+    <div class="card mb-3">
+        <div class="card-body">
+            <h5 class="card-title">@post.Title</h5>
+            <p class="card-text">@post.Content</p>
+            <a class="btn btn-sm btn-secondary" href="/Posts/Details/@post.Id">View</a>
+            @if (user == post.AuthorId)
+            {
+                <a class="btn btn-sm btn-warning" href="/Posts/Edit/@post.Id">Edit</a>
+                <form method="post" asp-action="Delete" asp-route-id="@post.Id" class="d-inline">
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            }
+        </div>
+    </div>
 }

--- a/BBS.Web/Views/Shared/_Layout.cshtml
+++ b/BBS.Web/Views/Shared/_Layout.cshtml
@@ -1,0 +1,38 @@
+@using Microsoft.AspNetCore.Http
+@{
+    var user = Context.Session.GetString("user");
+}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <title>@ViewData["Title"] - BBS</title>
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="/">BBS</a>
+            <div class="collapse navbar-collapse">
+                <ul class="navbar-nav ms-auto">
+                    @if (!string.IsNullOrEmpty(user))
+                    {
+                        <li class="nav-item"><span class="navbar-text me-2">@user</span></li>
+                        <li class="nav-item"><a class="nav-link" href="/Account/Logout">Logout</a></li>
+                    }
+                    else
+                    {
+                        <li class="nav-item"><a class="nav-link" href="/Account/Login">Login</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/Account/Register">Register</a></li>
+                    }
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container mt-4">
+        @RenderBody()
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/BBS.Web/Views/_ViewImports.cshtml
+++ b/BBS.Web/Views/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using BBS.Domain.Entities
+@using BBS.Web.Controllers
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/BBS.Web/Views/_ViewStart.cshtml
+++ b/BBS.Web/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}


### PR DESCRIPTION
## Summary
- Support registration and login with JWT token storage in session
- Enable creating, editing, viewing and deleting posts via API with ownership checks
- Introduce Bootstrap-based UI with shared layout and session-backed navigation

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68abe5a12c0c832fa55befeba3b47841