### PR TITLE
feat: add posts and member management

### DIFF
--- a/BBS.Api.Tests/UsersControllerTests.cs
+++ b/BBS.Api.Tests/UsersControllerTests.cs
@@ -1,0 +1,70 @@
+using BBS.Api.Controllers;
+using BBS.Application.Services;
+using BBS.Domain.Entities;
+using BBS.Domain.Repositories;
+using BBS.Infrastructure.Data;
+using BBS.Infrastructure.Repositories;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BBS.Api.Tests;
+
+public class UsersControllerTests
+{
+    private static (BbsContext context, UsersController controller) CreateController()
+    {
+        var options = new DbContextOptionsBuilder<BbsContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new BbsContext(options);
+        IRepository<User, string> repository = new Repository<User, string>(context);
+        IUserService service = new UserService(repository);
+        var controller = new UsersController(service);
+        return (context, controller);
+    }
+
+    [Fact]
+    public async Task GetUsers_ReturnsAllUsers()
+    {
+        var (context, controller) = CreateController();
+        using (context)
+        {
+            context.Users.Add(new User { Id = "a@example.com", Nickname = "a", PasswordHash = "p" });
+            context.Users.Add(new User { Id = "b@example.com", Nickname = "b", PasswordHash = "p" });
+            await context.SaveChangesAsync();
+
+            var result = await controller.GetUsers();
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var users = Assert.IsType<List<User>>(ok.Value);
+            Assert.Equal(2, users.Count);
+        }
+    }
+
+    [Fact]
+    public async Task GetUser_ReturnsUser_WhenExists()
+    {
+        var (context, controller) = CreateController();
+        using (context)
+        {
+            context.Users.Add(new User { Id = "a@example.com", Nickname = "a", PasswordHash = "p" });
+            await context.SaveChangesAsync();
+
+            var result = await controller.GetUser("a@example.com");
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var user = Assert.IsType<User>(ok.Value);
+            Assert.Equal("a@example.com", user.Id);
+        }
+    }
+
+    [Fact]
+    public async Task GetUser_ReturnsNotFound_WhenMissing()
+    {
+        var (context, controller) = CreateController();
+        using (context)
+        {
+            var result = await controller.GetUser("missing@example.com");
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+    }
+}

--- a/BBS.Api/Controllers/UsersController.cs
+++ b/BBS.Api/Controllers/UsersController.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using BBS.Application.Services;
+using BBS.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBS.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly IUserService _service;
+
+    public UsersController(IUserService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<User>>> GetUsers()
+    {
+        var users = await _service.GetUsersAsync();
+        return Ok(users);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<User>> GetUser(string id)
+    {
+        var user = await _service.GetUserAsync(id);
+        if (user == null) return NotFound();
+        return Ok(user);
+    }
+
+    [HttpDelete("{id}")]
+    [Authorize]
+    public async Task<IActionResult> DeleteUser(string id)
+    {
+        await _service.DeleteUserAsync(id);
+        return NoContent();
+    }
+}

--- a/BBS.Application/Services/IUserService.cs
+++ b/BBS.Application/Services/IUserService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using BBS.Domain.Entities;
 
 namespace BBS.Application.Services;
@@ -6,5 +7,8 @@ public interface IUserService
 {
     Task<bool> RegisterAsync(string email, string password, string nickname);
     Task<User?> AuthenticateAsync(string email, string password);
+    Task<List<User>> GetUsersAsync();
+    Task<User?> GetUserAsync(string email);
+    Task DeleteUserAsync(string email);
 }
 

--- a/BBS.Application/Services/UserService.cs
+++ b/BBS.Application/Services/UserService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -36,6 +37,21 @@ public class UserService : IUserService
         var user = await _repository.GetByIdAsync(email);
         if (user == null) return null;
         return user.PasswordHash == Hash(password) ? user : null;
+    }
+
+    public async Task<List<User>> GetUsersAsync()
+    {
+        return await _repository.GetAllAsync();
+    }
+
+    public async Task<User?> GetUserAsync(string email)
+    {
+        return await _repository.GetByIdAsync(email);
+    }
+
+    public async Task DeleteUserAsync(string email)
+    {
+        await _repository.DeleteAsync(email);
     }
 
     private static string Hash(string input)

--- a/BBS.Web/Controllers/MembersController.cs
+++ b/BBS.Web/Controllers/MembersController.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using BBS.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBS.Web.Controllers;
+
+public class MembersController : Controller
+{
+    private readonly IHttpClientFactory _factory;
+
+    public MembersController(IHttpClientFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private HttpClient CreateClient()
+    {
+        var client = _factory.CreateClient("BbsApi");
+        var token = HttpContext.Session.GetString("token");
+        if (!string.IsNullOrEmpty(token))
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var client = CreateClient();
+        var users = await client.GetFromJsonAsync<List<User>>("api/users");
+        return View(users ?? new List<User>());
+    }
+
+    public async Task<IActionResult> Details(string id)
+    {
+        var client = CreateClient();
+        var user = await client.GetFromJsonAsync<User>($"api/users/{id}");
+        if (user == null) return NotFound();
+        return View(user);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Delete(string id)
+    {
+        if (HttpContext.Session.GetString("token") == null)
+            return RedirectToAction("Login", "Account");
+        var client = CreateClient();
+        await client.DeleteAsync($"api/users/{id}");
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/BBS.Web/Views/Members/Details.cshtml
+++ b/BBS.Web/Views/Members/Details.cshtml
@@ -1,0 +1,12 @@
+@model BBS.Domain.Entities.User
+@{
+    ViewData["Title"] = "Member Details";
+}
+<h1>Member Details</h1>
+<dl class="row">
+    <dt class="col-sm-2">Email</dt>
+    <dd class="col-sm-10">@Model.Id</dd>
+    <dt class="col-sm-2">Nickname</dt>
+    <dd class="col-sm-10">@Model.Nickname</dd>
+</dl>
+<a class="btn btn-secondary" asp-action="Index">Back to List</a>

--- a/BBS.Web/Views/Members/Index.cshtml
+++ b/BBS.Web/Views/Members/Index.cshtml
@@ -1,0 +1,32 @@
+@model IEnumerable<BBS.Domain.Entities.User>
+@{
+    ViewData["Title"] = "Members";
+}
+<h1>Members</h1>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Email</th>
+            <th>Nickname</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var user in Model)
+    {
+        <tr>
+            <td>@user.Id</td>
+            <td>@user.Nickname</td>
+            <td>
+                <a class="btn btn-sm btn-secondary" asp-action="Details" asp-route-id="@user.Id">Details</a>
+                @if (Context.Session.GetString("token") != null)
+                {
+                    <form asp-action="Delete" asp-route-id="@user.Id" method="post" style="display:inline">
+                        <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                    </form>
+                }
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/BBS.Web/Views/Shared/_Layout.cshtml
+++ b/BBS.Web/Views/Shared/_Layout.cshtml
@@ -16,6 +16,7 @@
             <a class="navbar-brand" href="/">BBS</a>
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link" href="/Members">Members</a></li>
                     @if (!string.IsNullOrEmpty(user))
                     {
                         <li class="nav-item"><span class="navbar-text me-2">@user</span></li>


### PR DESCRIPTION
## Summary
- extend user service with list, fetch, and delete helpers
- expose user retrieval and removal endpoints and tests
- add member management pages and navigation to web app

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68abf40bcd64832fad9e901634ca8f22