### PR TITLE
feat: switch to SQL Server and enhance validation

### DIFF
--- a/BBS.Api.Tests/PostServiceTests.cs
+++ b/BBS.Api.Tests/PostServiceTests.cs
@@ -1,0 +1,32 @@
+using BBS.Application.Services;
+using BBS.Domain.Entities;
+using BBS.Infrastructure.Data;
+using BBS.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BBS.Api.Tests;
+
+public class PostServiceTests
+{
+    private static PostService CreateService()
+    {
+        var options = new DbContextOptionsBuilder<BbsContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new BbsContext(options);
+        var postRepo = new Repository<Post, int>(context);
+        var commentRepo = new Repository<Comment, int>(context);
+        return new PostService(postRepo, commentRepo);
+    }
+
+    [Fact]
+    public async Task CreatePostAsync_Throws_WhenTitleMissing()
+    {
+        var service = CreateService();
+        var post = new Post { Title = "", Content = "content" };
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => service.CreatePostAsync(post, "user@example.com"));
+    }
+}

--- a/BBS.Api/Program.cs
+++ b/BBS.Api/Program.cs
@@ -1,9 +1,6 @@
 using BBS.Application.Services;
-using BBS.Domain.Repositories;
-using BBS.Infrastructure.Data;
-using BBS.Infrastructure.Repositories;
+using BBS.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 
@@ -12,10 +9,8 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddControllers();
 
-// Configure EF Core and repositories
-builder.Services.AddDbContext<BbsContext>(options =>
-    options.UseInMemoryDatabase("Bbs"));
-builder.Services.AddScoped(typeof(IRepository<,>), typeof(Repository<,>));
+// Configure infrastructure and application services
+builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddScoped<IPostService, PostService>();
 builder.Services.AddScoped<IUserService, UserService>();
 

--- a/BBS.Application/Services/IPostService.cs
+++ b/BBS.Application/Services/IPostService.cs
@@ -9,8 +9,8 @@ public interface IPostService
     Task<IEnumerable<Post>> GetPostsAsync();
     Task<Post?> GetPostAsync(int id);
     Task<Post> CreatePostAsync(Post post, string authorId);
-    Task<bool> UpdatePostAsync(Post post, string userId);
-    Task<bool> DeletePostAsync(int id, string userId);
+    Task UpdatePostAsync(Post post, string userId);
+    Task DeletePostAsync(int id, string userId);
     Task<Comment> AddCommentAsync(int postId, Comment comment);
     Task<IEnumerable<Comment>> GetCommentsAsync(int postId);
 }

--- a/BBS.Application/Services/PostService.cs
+++ b/BBS.Application/Services/PostService.cs
@@ -23,30 +23,41 @@ public class PostService : IPostService
 
     public Task<Post> CreatePostAsync(Post post, string authorId)
     {
+        if (string.IsNullOrWhiteSpace(post.Title))
+            throw new ArgumentException("Title is required", nameof(post));
+        if (string.IsNullOrWhiteSpace(post.Content))
+            throw new ArgumentException("Content is required", nameof(post));
+
         post.AuthorId = authorId;
         return _posts.AddAsync(post);
     }
 
-    public async Task<bool> UpdatePostAsync(Post post, string userId)
+    public async Task UpdatePostAsync(Post post, string userId)
     {
+        if (string.IsNullOrWhiteSpace(post.Title) || string.IsNullOrWhiteSpace(post.Content))
+            throw new ArgumentException("Title and content are required", nameof(post));
+
         var existing = await _posts.GetByIdAsync(post.Id);
-        if (existing == null || existing.AuthorId != userId) return false;
+        if (existing == null) throw new KeyNotFoundException("Post not found");
+        if (existing.AuthorId != userId) throw new UnauthorizedAccessException("Cannot edit others' posts");
         existing.Title = post.Title;
         existing.Content = post.Content;
         await _posts.UpdateAsync(existing);
-        return true;
     }
 
-    public async Task<bool> DeletePostAsync(int id, string userId)
+    public async Task DeletePostAsync(int id, string userId)
     {
         var existing = await _posts.GetByIdAsync(id);
-        if (existing == null || existing.AuthorId != userId) return false;
+        if (existing == null) throw new KeyNotFoundException("Post not found");
+        if (existing.AuthorId != userId) throw new UnauthorizedAccessException("Cannot delete others' posts");
         await _posts.DeleteAsync(id);
-        return true;
     }
 
     public async Task<Comment> AddCommentAsync(int postId, Comment comment)
     {
+        if (string.IsNullOrWhiteSpace(comment.Content))
+            throw new ArgumentException("Content is required", nameof(comment));
+
         var post = await _posts.GetByIdAsync(postId);
         if (post == null) throw new InvalidOperationException("Post not found");
         comment.PostId = postId;
@@ -55,6 +66,8 @@ public class PostService : IPostService
 
     public async Task<IEnumerable<Comment>> GetCommentsAsync(int postId)
     {
+        var post = await _posts.GetByIdAsync(postId);
+        if (post == null) throw new InvalidOperationException("Post not found");
         var comments = await _comments.GetAllAsync();
         return comments.Where(c => c.PostId == postId);
     }

--- a/BBS.Infrastructure/BBS.Infrastructure.csproj
+++ b/BBS.Infrastructure/BBS.Infrastructure.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\\BBS.Domain\\BBS.Domain.csproj" />

--- a/BBS.Infrastructure/DependencyInjection.cs
+++ b/BBS.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,28 @@
+using BBS.Domain.Repositories;
+using BBS.Infrastructure.Data;
+using BBS.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BBS.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        if (configuration.GetValue<bool>("UseInMemoryDatabase"))
+        {
+            services.AddDbContext<BbsContext>(options =>
+                options.UseInMemoryDatabase("Bbs"));
+        }
+        else
+        {
+            services.AddDbContext<BbsContext>(options =>
+                options.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
+        }
+
+        services.AddScoped(typeof(IRepository<,>), typeof(Repository<,>));
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize EF Core setup in Infrastructure with SQL Server support
- add input validation and explicit exceptions in PostService and controller
- add service-level test for invalid post creation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68abfe4b4e40832fa4445f556f03be42