### PR TITLE
Add role support to user accounts

### DIFF
--- a/BBS.Api.Tests/AuthControllerTests.cs
+++ b/BBS.Api.Tests/AuthControllerTests.cs
@@ -1,6 +1,7 @@
 using BBS.Api.Controllers;
 using BBS.Application.Services;
 using BBS.Domain.Entities;
+using BBS.Domain.Enums;
 using BBS.Domain.Repositories;
 using BBS.Infrastructure.Data;
 using BBS.Infrastructure.Repositories;
@@ -55,6 +56,19 @@ public class AuthControllerTests
             await controller.Register(new RegisterDto("test1@example.com", "pass", "nick"));
             var result = await controller.Register(new RegisterDto("test2@example.com", "pass", "nick"));
             Assert.IsType<ConflictResult>(result);
+        }
+    }
+
+    [Fact]
+    public async Task Register_AssignsReaderRoleByDefault()
+    {
+        var (context, controller) = CreateController();
+        using (context)
+        {
+            await controller.Register(new RegisterDto("test@example.com", "pass", "nick"));
+            var user = await context.Users.FindAsync("test@example.com");
+            Assert.NotNull(user);
+            Assert.Contains(Role.Reader, user!.Roles);
         }
     }
 }

--- a/BBS.Api.Tests/UsersControllerTests.cs
+++ b/BBS.Api.Tests/UsersControllerTests.cs
@@ -1,6 +1,7 @@
 using BBS.Api.Controllers;
 using BBS.Application.Services;
 using BBS.Domain.Entities;
+using BBS.Domain.Enums;
 using BBS.Domain.Repositories;
 using BBS.Infrastructure.Data;
 using BBS.Infrastructure.Repositories;
@@ -54,6 +55,7 @@ public class UsersControllerTests
             var ok = Assert.IsType<OkObjectResult>(result.Result);
             var user = Assert.IsType<User>(ok.Value);
             Assert.Equal("a@example.com", user.Id);
+            Assert.Contains(Role.Reader, user.Roles);
         }
     }
 

--- a/BBS.Api/Controllers/AuthController.cs
+++ b/BBS.Api/Controllers/AuthController.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using System.Linq;
 using BBS.Application.Services;
 using BBS.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
@@ -45,7 +46,8 @@ public class AuthController : ControllerBase
         var token = new JwtSecurityToken(
             issuer: _configuration["Jwt:Issuer"],
             audience: _configuration["Jwt:Audience"],
-            claims: new[] { new Claim(ClaimTypes.Name, user.Id) },
+            claims: new[] { new Claim(ClaimTypes.Name, user.Id) }
+                .Concat(user.Roles.Select(r => new Claim(ClaimTypes.Role, r.ToString()))),
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: creds);
         return new JwtSecurityTokenHandler().WriteToken(token);

--- a/BBS.Application/Services/IUserService.cs
+++ b/BBS.Application/Services/IUserService.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
 using BBS.Domain.Entities;
+using BBS.Domain.Enums;
 
 namespace BBS.Application.Services;
 
 public interface IUserService
 {
-    Task<bool> RegisterAsync(string email, string password, string nickname);
+    Task<bool> RegisterAsync(string email, string password, string nickname, IEnumerable<Role>? roles = null);
     Task<User?> AuthenticateAsync(string email, string password);
     Task<List<User>> GetUsersAsync();
     Task<User?> GetUserAsync(string email);

--- a/BBS.Application/Services/UserService.cs
+++ b/BBS.Application/Services/UserService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using BBS.Domain.Entities;
+using BBS.Domain.Enums;
 using BBS.Domain.Repositories;
 
 namespace BBS.Application.Services;
@@ -17,7 +18,7 @@ public class UserService : IUserService
         _repository = repository;
     }
 
-    public async Task<bool> RegisterAsync(string email, string password, string nickname)
+    public async Task<bool> RegisterAsync(string email, string password, string nickname, IEnumerable<Role>? roles = null)
     {
         if (await _repository.GetByIdAsync(email) != null) return false;
         if ((await _repository.GetAllAsync()).Any(u => u.Nickname == nickname)) return false;
@@ -26,7 +27,8 @@ public class UserService : IUserService
         {
             Id = email,
             Nickname = nickname,
-            PasswordHash = Hash(password)
+            PasswordHash = Hash(password),
+            Roles = roles?.ToList() ?? new List<Role> { Role.Reader }
         };
         await _repository.AddAsync(user);
         return true;

--- a/BBS.Domain/Entities/User.cs
+++ b/BBS.Domain/Entities/User.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using BBS.Domain.Enums;
 
 namespace BBS.Domain.Entities;
 
@@ -12,5 +14,7 @@ public class User
 
     [Required]
     public string PasswordHash { get; set; } = default!;
+
+    public List<Role> Roles { get; set; } = new() { Role.Reader };
 }
 

--- a/BBS.Domain/Enums/Role.cs
+++ b/BBS.Domain/Enums/Role.cs
@@ -1,0 +1,8 @@
+namespace BBS.Domain.Enums;
+
+public enum Role
+{
+    Administrator,
+    Writer,
+    Reader
+}

--- a/BBS.Web/Views/Members/Details.cshtml
+++ b/BBS.Web/Views/Members/Details.cshtml
@@ -8,5 +8,7 @@
     <dd class="col-sm-10">@Model.Id</dd>
     <dt class="col-sm-2">Nickname</dt>
     <dd class="col-sm-10">@Model.Nickname</dd>
+    <dt class="col-sm-2">Roles</dt>
+    <dd class="col-sm-10">@string.Join(", ", Model.Roles)</dd>
 </dl>
 <a class="btn btn-secondary" asp-action="Index">Back to List</a>

--- a/BBS.Web/Views/Members/Index.cshtml
+++ b/BBS.Web/Views/Members/Index.cshtml
@@ -8,6 +8,7 @@
         <tr>
             <th>Email</th>
             <th>Nickname</th>
+            <th>Roles</th>
             <th></th>
         </tr>
     </thead>
@@ -17,6 +18,7 @@
         <tr>
             <td>@user.Id</td>
             <td>@user.Nickname</td>
+            <td>@string.Join(", ", user.Roles)</td>
             <td>
                 <a class="btn btn-sm btn-secondary" asp-action="Details" asp-route-id="@user.Id">Details</a>
                 @if (Context.Session.GetString("token") != null)


### PR DESCRIPTION
## Summary
- introduce Role enum and associate multiple roles with each User
- extend user service and auth token generation to handle roles
- display user roles in web member views and verify default role in tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac0bd2e9b0832fae53d2a46f1bf1c7