### PR TITLE
Refactor user primary keys to integers

### DIFF
--- a/BBS.Api.Tests/AuthControllerTests.cs
+++ b/BBS.Api.Tests/AuthControllerTests.cs
@@ -66,7 +66,7 @@ public class AuthControllerTests
         using (context)
         {
             await controller.Register(new RegisterDto("test@example.com", "pass", "nick"));
-            var user = await context.Users.FindAsync("test@example.com");
+            var user = await context.Users.FirstOrDefaultAsync(u => u.LoginId == "test@example.com");
             Assert.NotNull(user);
             Assert.Contains(Role.Reader, user!.Roles);
         }

--- a/BBS.Api.Tests/PostServiceTests.cs
+++ b/BBS.Api.Tests/PostServiceTests.cs
@@ -27,6 +27,6 @@ public class PostServiceTests
         var post = new Post { Title = "", Content = "content" };
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => service.CreatePostAsync(post, "user@example.com"));
+            () => service.CreatePostAsync(post, 1));
     }
 }

--- a/BBS.Api.Tests/PostsControllerTests.cs
+++ b/BBS.Api.Tests/PostsControllerTests.cs
@@ -31,7 +31,7 @@ public class PostsControllerTests
                 {
                     User = new ClaimsPrincipal(new ClaimsIdentity(new[]
                     {
-                        new Claim(ClaimTypes.Name, "user@example.com")
+                        new Claim(ClaimTypes.Name, "1")
                     }))
                 }
             }
@@ -64,7 +64,7 @@ public class PostsControllerTests
             var createdPost = Assert.IsType<Post>(created.Value);
 
             Assert.Equal("Hello", createdPost.Title);
-            Assert.Equal("user@example.com", createdPost.AuthorId);
+            Assert.Equal(1, createdPost.AuthorId);
             Assert.Single(context.Posts);
         }
     }

--- a/BBS.Api.Tests/UsersControllerTests.cs
+++ b/BBS.Api.Tests/UsersControllerTests.cs
@@ -31,8 +31,8 @@ public class UsersControllerTests
         var (context, controller) = CreateController();
         using (context)
         {
-            context.Users.Add(new User { Id = "a@example.com", Nickname = "a", PasswordHash = "p" });
-            context.Users.Add(new User { Id = "b@example.com", Nickname = "b", PasswordHash = "p" });
+            context.Users.Add(new User { LoginId = "a@example.com", Nickname = "a", PasswordHash = "p" });
+            context.Users.Add(new User { LoginId = "b@example.com", Nickname = "b", PasswordHash = "p" });
             await context.SaveChangesAsync();
 
             var result = await controller.GetUsers();
@@ -48,13 +48,13 @@ public class UsersControllerTests
         var (context, controller) = CreateController();
         using (context)
         {
-            context.Users.Add(new User { Id = "a@example.com", Nickname = "a", PasswordHash = "p" });
+            context.Users.Add(new User { LoginId = "a@example.com", Nickname = "a", PasswordHash = "p" });
             await context.SaveChangesAsync();
 
             var result = await controller.GetUser("a@example.com");
             var ok = Assert.IsType<OkObjectResult>(result.Result);
             var user = Assert.IsType<User>(ok.Value);
-            Assert.Equal("a@example.com", user.Id);
+            Assert.Equal("a@example.com", user.LoginId);
             Assert.Contains(Role.Reader, user.Roles);
         }
     }

--- a/BBS.Api/Controllers/AuthController.cs
+++ b/BBS.Api/Controllers/AuthController.cs
@@ -46,7 +46,7 @@ public class AuthController : ControllerBase
         var token = new JwtSecurityToken(
             issuer: _configuration["Jwt:Issuer"],
             audience: _configuration["Jwt:Audience"],
-            claims: new[] { new Claim(ClaimTypes.Name, user.Id) }
+            claims: new[] { new Claim(ClaimTypes.Name, user.Id.ToString()) }
                 .Concat(user.Roles.Select(r => new Claim(ClaimTypes.Role, r.ToString()))),
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: creds);

--- a/BBS.Api/Controllers/PostsController.cs
+++ b/BBS.Api/Controllers/PostsController.cs
@@ -41,7 +41,7 @@ public class PostsController : ControllerBase
     {
         try
         {
-            var userId = User.Identity!.Name!;
+            var userId = int.Parse(User.Identity!.Name!);
             var created = await _service.CreatePostAsync(post, userId);
             return CreatedAtAction(nameof(GetPost), new { id = created.Id }, created);
         }
@@ -55,7 +55,7 @@ public class PostsController : ControllerBase
     [Authorize]
     public async Task<IActionResult> UpdatePost(int id, Post post)
     {
-        var userId = User.Identity!.Name!;
+        var userId = int.Parse(User.Identity!.Name!);
         post.Id = id;
         try
         {
@@ -80,7 +80,7 @@ public class PostsController : ControllerBase
     [Authorize]
     public async Task<IActionResult> DeletePost(int id)
     {
-        var userId = User.Identity!.Name!;
+        var userId = int.Parse(User.Identity!.Name!);
         try
         {
             await _service.DeletePostAsync(id, userId);

--- a/BBS.Api/Controllers/UsersController.cs
+++ b/BBS.Api/Controllers/UsersController.cs
@@ -24,19 +24,19 @@ public class UsersController : ControllerBase
         return Ok(users);
     }
 
-    [HttpGet("{id}")]
-    public async Task<ActionResult<User>> GetUser(string id)
+    [HttpGet("{loginId}")]
+    public async Task<ActionResult<User>> GetUser(string loginId)
     {
-        var user = await _service.GetUserAsync(id);
+        var user = await _service.GetUserAsync(loginId);
         if (user == null) return NotFound();
         return Ok(user);
     }
 
-    [HttpDelete("{id}")]
+    [HttpDelete("{loginId}")]
     [Authorize]
-    public async Task<IActionResult> DeleteUser(string id)
+    public async Task<IActionResult> DeleteUser(string loginId)
     {
-        await _service.DeleteUserAsync(id);
+        await _service.DeleteUserAsync(loginId);
         return NoContent();
     }
 }

--- a/BBS.Application/Services/IPostService.cs
+++ b/BBS.Application/Services/IPostService.cs
@@ -8,9 +8,9 @@ public interface IPostService
 {
     Task<IEnumerable<Post>> GetPostsAsync();
     Task<Post?> GetPostAsync(int id);
-    Task<Post> CreatePostAsync(Post post, string authorId);
-    Task UpdatePostAsync(Post post, string userId);
-    Task DeletePostAsync(int id, string userId);
+    Task<Post> CreatePostAsync(Post post, int authorId);
+    Task UpdatePostAsync(Post post, int userId);
+    Task DeletePostAsync(int id, int userId);
     Task<Comment> AddCommentAsync(int postId, Comment comment);
     Task<IEnumerable<Comment>> GetCommentsAsync(int postId);
 }

--- a/BBS.Application/Services/IUserService.cs
+++ b/BBS.Application/Services/IUserService.cs
@@ -6,10 +6,10 @@ namespace BBS.Application.Services;
 
 public interface IUserService
 {
-    Task<bool> RegisterAsync(string email, string password, string nickname, IEnumerable<Role>? roles = null);
-    Task<User?> AuthenticateAsync(string email, string password);
+    Task<bool> RegisterAsync(string loginId, string password, string nickname, IEnumerable<Role>? roles = null);
+    Task<User?> AuthenticateAsync(string loginId, string password);
     Task<List<User>> GetUsersAsync();
-    Task<User?> GetUserAsync(string email);
-    Task DeleteUserAsync(string email);
+    Task<User?> GetUserAsync(string loginId);
+    Task DeleteUserAsync(string loginId);
 }
 

--- a/BBS.Application/Services/PostService.cs
+++ b/BBS.Application/Services/PostService.cs
@@ -21,7 +21,7 @@ public class PostService : IPostService
 
     public Task<Post?> GetPostAsync(int id) => _posts.GetByIdAsync(id);
 
-    public Task<Post> CreatePostAsync(Post post, string authorId)
+    public Task<Post> CreatePostAsync(Post post, int authorId)
     {
         if (string.IsNullOrWhiteSpace(post.Title))
             throw new ArgumentException("Title is required", nameof(post));
@@ -32,7 +32,7 @@ public class PostService : IPostService
         return _posts.AddAsync(post);
     }
 
-    public async Task UpdatePostAsync(Post post, string userId)
+    public async Task UpdatePostAsync(Post post, int userId)
     {
         if (string.IsNullOrWhiteSpace(post.Title) || string.IsNullOrWhiteSpace(post.Content))
             throw new ArgumentException("Title and content are required", nameof(post));
@@ -45,7 +45,7 @@ public class PostService : IPostService
         await _posts.UpdateAsync(existing);
     }
 
-    public async Task DeletePostAsync(int id, string userId)
+    public async Task DeletePostAsync(int id, int userId)
     {
         var existing = await _posts.GetByIdAsync(id);
         if (existing == null) throw new KeyNotFoundException("Post not found");

--- a/BBS.Domain/Entities/Post.cs
+++ b/BBS.Domain/Entities/Post.cs
@@ -7,6 +7,6 @@ public class Post
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
-    public string AuthorId { get; set; } = string.Empty;
+    public int AuthorId { get; set; }
     public List<Comment> Comments { get; set; } = new();
 }

--- a/BBS.Domain/Entities/User.cs
+++ b/BBS.Domain/Entities/User.cs
@@ -7,7 +7,10 @@ namespace BBS.Domain.Entities;
 public class User
 {
     [Key]
-    public string Id { get; set; } = default!; // Email as ID
+    public int Id { get; set; }
+
+    [Required]
+    public string LoginId { get; set; } = default!; // Email as login ID
 
     [Required]
     public string Nickname { get; set; } = default!;

--- a/BBS.Domain/Repositories/IRepository.cs
+++ b/BBS.Domain/Repositories/IRepository.cs
@@ -5,9 +5,9 @@ namespace BBS.Domain.Repositories;
 public interface IRepository<T> where T : class
 {
     Task<List<T>> GetAllAsync();
-    Task<T?> GetByIdAsync(object id);
+    Task<T?> GetByIdAsync(int id);
     Task<T> AddAsync(T entity);
     Task UpdateAsync(T entity);
-    Task DeleteAsync(object id);
+    Task DeleteAsync(int id);
 }
 

--- a/BBS.Infrastructure/Repositories/Repository.cs
+++ b/BBS.Infrastructure/Repositories/Repository.cs
@@ -21,7 +21,7 @@ public class Repository<T> : IRepository<T> where T : class
         return await _dbSet.ToListAsync();
     }
 
-    public virtual async Task<T?> GetByIdAsync(object id)
+    public virtual async Task<T?> GetByIdAsync(int id)
     {
         return await _dbSet.FindAsync(id).AsTask();
     }
@@ -39,7 +39,7 @@ public class Repository<T> : IRepository<T> where T : class
         await _context.SaveChangesAsync();
     }
 
-    public virtual async Task DeleteAsync(object id)
+    public virtual async Task DeleteAsync(int id)
     {
         var entity = await GetByIdAsync(id);
         if (entity != null)

--- a/BBS.Web/Controllers/AccountController.cs
+++ b/BBS.Web/Controllers/AccountController.cs
@@ -47,9 +47,10 @@ public class AccountController : Controller
             return View(dto);
         }
         HttpContext.Session.SetString("token", result.token);
-        var email = GetEmailFromToken(result.token);
-        if (email != null)
-            HttpContext.Session.SetString("user", email);
+        var userId = GetUserIdFromToken(result.token);
+        if (userId != null)
+            HttpContext.Session.SetString("userId", userId);
+        HttpContext.Session.SetString("user", dto.Email);
         return RedirectToAction("Index", "Posts");
     }
 
@@ -57,10 +58,11 @@ public class AccountController : Controller
     {
         HttpContext.Session.Remove("token");
         HttpContext.Session.Remove("user");
+        HttpContext.Session.Remove("userId");
         return RedirectToAction("Index", "Posts");
     }
 
-    private static string? GetEmailFromToken(string token)
+    private static string? GetUserIdFromToken(string token)
     {
         var parts = token.Split('.');
         if (parts.Length < 2) return null;

--- a/BBS.Web/Views/Members/Details.cshtml
+++ b/BBS.Web/Views/Members/Details.cshtml
@@ -5,7 +5,7 @@
 <h1>Member Details</h1>
 <dl class="row">
     <dt class="col-sm-2">Email</dt>
-    <dd class="col-sm-10">@Model.Id</dd>
+    <dd class="col-sm-10">@Model.LoginId</dd>
     <dt class="col-sm-2">Nickname</dt>
     <dd class="col-sm-10">@Model.Nickname</dd>
     <dt class="col-sm-2">Roles</dt>

--- a/BBS.Web/Views/Members/Index.cshtml
+++ b/BBS.Web/Views/Members/Index.cshtml
@@ -16,14 +16,14 @@
     @foreach (var user in Model)
     {
         <tr>
-            <td>@user.Id</td>
+            <td>@user.LoginId</td>
             <td>@user.Nickname</td>
             <td>@string.Join(", ", user.Roles)</td>
             <td>
-                <a class="btn btn-sm btn-secondary" asp-action="Details" asp-route-id="@user.Id">Details</a>
+                <a class="btn btn-sm btn-secondary" asp-action="Details" asp-route-id="@user.LoginId">Details</a>
                 @if (Context.Session.GetString("token") != null)
                 {
-                    <form asp-action="Delete" asp-route-id="@user.Id" method="post" style="display:inline">
+                    <form asp-action="Delete" asp-route-id="@user.LoginId" method="post" style="display:inline">
                         <button type="submit" class="btn btn-sm btn-danger">Delete</button>
                     </form>
                 }

--- a/BBS.Web/Views/Posts/Details.cshtml
+++ b/BBS.Web/Views/Posts/Details.cshtml
@@ -1,7 +1,7 @@
 @model Post
 @{
     ViewData["Title"] = "Post Details";
-    var user = Context.Session.GetString("user");
+    var userId = Context.Session.GetString("userId");
 }
 
 <div class="card">
@@ -9,7 +9,7 @@
         <h5 class="card-title">@Model.Title</h5>
         <p class="card-text">@Model.Content</p>
         <a asp-action="Index" class="btn btn-secondary">Back</a>
-        @if (user == Model.AuthorId)
+        @if (userId != null && int.Parse(userId) == Model.AuthorId)
         {
             <a class="btn btn-warning" href="/Posts/Edit/@Model.Id">Edit</a>
         }

--- a/BBS.Web/Views/Posts/Index.cshtml
+++ b/BBS.Web/Views/Posts/Index.cshtml
@@ -1,12 +1,12 @@
 @model IEnumerable<Post>
 @{
     ViewData["Title"] = "Posts";
-    var user = Context.Session.GetString("user");
+    var userId = Context.Session.GetString("userId");
 }
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>Posts</h1>
-    @if (user != null)
+    @if (userId != null)
     {
         <a class="btn btn-primary" href="/Posts/Create">New Post</a>
     }
@@ -19,7 +19,7 @@
             <h5 class="card-title">@post.Title</h5>
             <p class="card-text">@post.Content</p>
             <a class="btn btn-sm btn-secondary" href="/Posts/Details/@post.Id">View</a>
-            @if (user == post.AuthorId)
+            @if (userId != null && int.Parse(userId) == post.AuthorId)
             {
                 <a class="btn btn-sm btn-warning" href="/Posts/Edit/@post.Id">Edit</a>
                 <form method="post" asp-action="Delete" asp-route-id="@post.Id" class="d-inline">


### PR DESCRIPTION
## Summary
- replace User string Id with LoginId and add int Id primary key
- update repositories and services to use integer identifiers
- adjust API, web UI, and tests for numeric user IDs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac0dceeca4832f903b819edc530980