### PR TITLE
Handle attachment metadata and settings

### DIFF
--- a/BBS.Api.Tests/PostServiceTests.cs
+++ b/BBS.Api.Tests/PostServiceTests.cs
@@ -19,7 +19,10 @@ public class PostServiceTests
         var postRepo = new Repository<Post>(context);
         var commentRepo = new Repository<Comment>(context);
         var attachmentRepo = new Repository<Attachment>(context);
-        return new PostService(postRepo, commentRepo, attachmentRepo);
+        var settingRepo = new Repository<BbsSetting>(context);
+        context.BbsSettings.Add(new BbsSetting { AllowedFileExtensions = "txt" });
+        context.SaveChanges();
+        return new PostService(postRepo, commentRepo, attachmentRepo, settingRepo);
     }
 
     [Fact]
@@ -37,8 +40,8 @@ public class PostServiceTests
     {
         var service = CreateService();
         var post = await service.CreatePostAsync(new Post { Title = "t", Content = "c" }, 1);
-        await service.AddAttachmentAsync(post.Id, new Attachment { FileName = "a1.txt" });
-        await service.AddAttachmentAsync(post.Id, new Attachment { FileName = "a2.txt" });
+        await service.AddAttachmentAsync(post.Id, new Attachment { FileName = "a1.txt", FileUrl = "http://example.com/a1.txt" });
+        await service.AddAttachmentAsync(post.Id, new Attachment { FileName = "a2.txt", FileUrl = "http://example.com/a2.txt" });
 
         var attachments = await service.GetAttachmentsAsync(post.Id);
         Assert.Equal(2, attachments.Count());

--- a/BBS.Api.Tests/PostsControllerTests.cs
+++ b/BBS.Api.Tests/PostsControllerTests.cs
@@ -23,7 +23,10 @@ public class PostsControllerTests
         IRepository<Post> postRepository = new Repository<Post>(context);
         IRepository<Comment> commentRepository = new Repository<Comment>(context);
         IRepository<Attachment> attachmentRepository = new Repository<Attachment>(context);
-        IPostService service = new PostService(postRepository, commentRepository, attachmentRepository);
+        IRepository<BbsSetting> settingRepository = new Repository<BbsSetting>(context);
+        context.BbsSettings.Add(new BbsSetting { AllowedFileExtensions = "txt" });
+        context.SaveChanges();
+        IPostService service = new PostService(postRepository, commentRepository, attachmentRepository, settingRepository);
         var controller = new PostsController(service)
         {
             ControllerContext = new ControllerContext
@@ -79,7 +82,7 @@ public class PostsControllerTests
             var postResult = await controller.CreatePost(new Post { Title = "Hello", Content = "World" });
             var createdPost = Assert.IsType<Post>(Assert.IsType<CreatedAtActionResult>(postResult.Result).Value);
 
-            var attachment = new Attachment { FileName = "file.txt" };
+            var attachment = new Attachment { FileName = "file.txt", FileUrl = "http://example.com/file.txt" };
             var result = await controller.AddAttachment(createdPost.Id, attachment);
             var created = Assert.IsType<CreatedAtActionResult>(result.Result);
             var createdAttachment = Assert.IsType<Attachment>(created.Value);

--- a/BBS.Domain/Entities/Attachment.cs
+++ b/BBS.Domain/Entities/Attachment.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace BBS.Domain.Entities;
 
 public class Attachment
@@ -7,7 +5,7 @@ public class Attachment
     public int Id { get; set; }
     public int PostId { get; set; }
     public string FileName { get; set; } = string.Empty;
-    public byte[] Content { get; set; } = Array.Empty<byte>();
+    public string FileUrl { get; set; } = string.Empty;
     public Post? Post { get; set; }
 }
 

--- a/BBS.Domain/Entities/BbsSetting.cs
+++ b/BBS.Domain/Entities/BbsSetting.cs
@@ -1,0 +1,7 @@
+namespace BBS.Domain.Entities;
+
+public class BbsSetting
+{
+    public int Id { get; set; }
+    public string AllowedFileExtensions { get; set; } = string.Empty;
+}

--- a/BBS.Infrastructure/Data/BbsContext.cs
+++ b/BBS.Infrastructure/Data/BbsContext.cs
@@ -13,6 +13,7 @@ public class BbsContext : DbContext
     public DbSet<Role> Roles => Set<Role>();
     public DbSet<UserRole> UserRoles => Set<UserRole>();
     public DbSet<Attachment> Attachments => Set<Attachment>();
+    public DbSet<BbsSetting> BbsSettings => Set<BbsSetting>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
## Summary
- Store only file name and URL for attachments
- Introduce `BbsSetting` to manage allowed attachment file types
- Validate attachments against allowed file extensions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac1cb54080832f968b57c1bde567e3