### PR TITLE
Refactor repository to improve query performance

### DIFF
--- a/BBS.Application/Services/PostService.cs
+++ b/BBS.Application/Services/PostService.cs
@@ -77,8 +77,7 @@ public class PostService : IPostService
     {
         var post = await _posts.GetByIdAsync(postId);
         if (post == null) throw new InvalidOperationException("Post not found");
-        var comments = await _comments.GetAllAsync();
-        return comments.Where(c => c.PostId == postId);
+        return await _comments.FindAsync(c => c.PostId == postId);
     }
 
     public async Task<Attachment> AddAttachmentAsync(int postId, Attachment attachment)
@@ -111,7 +110,6 @@ public class PostService : IPostService
     {
         var post = await _posts.GetByIdAsync(postId);
         if (post == null) throw new InvalidOperationException("Post not found");
-        var attachments = await _attachments.GetAllAsync();
-        return attachments.Where(a => a.PostId == postId);
+        return await _attachments.FindAsync(a => a.PostId == postId);
     }
 }

--- a/BBS.Domain/Repositories/IRepository.cs
+++ b/BBS.Domain/Repositories/IRepository.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace BBS.Domain.Repositories;
 
 public interface IRepository<T> where T : class
 {
     Task<List<T>> GetAllAsync();
+    Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate);
     Task<T?> GetByIdAsync(int id);
     Task<T> AddAsync(T entity);
     Task UpdateAsync(T entity);

--- a/BBS.Infrastructure/Repositories/Repository.cs
+++ b/BBS.Infrastructure/Repositories/Repository.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using BBS.Domain.Repositories;
 using BBS.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
@@ -19,6 +21,11 @@ public class Repository<T> : IRepository<T> where T : class
     public virtual async Task<List<T>> GetAllAsync()
     {
         return await _dbSet.ToListAsync();
+    }
+
+    public virtual async Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate)
+    {
+        return await _dbSet.Where(predicate).ToListAsync();
     }
 
     public virtual async Task<T?> GetByIdAsync(int id)


### PR DESCRIPTION
The PostService was fetching entire tables (comments, attachments, settings) into memory and then filtering them using LINQ. This is inefficient and can lead to significant performance degradation as the database grows.

This commit introduces a `FindAsync` method to the generic repository (`IRepository<T>` and `Repository<T>`) that accepts a predicate. This allows filtering to be performed at the database level.

The `PostService` has been refactored to use this new method for fetching comments and attachments, ensuring that only the necessary data is retrieved from the database.